### PR TITLE
Adds analysis option to database check script

### DIFF
--- a/chamber/analysis/experiments.py
+++ b/chamber/analysis/experiments.py
@@ -206,6 +206,8 @@ def mass_transfer(dataframe, sigma=4e-8, steps=100, plot=False):
                             _half_len_gen(dataframe, idx, steps=steps),
                             repeat(idx), repeat(steps),
                             repeat(sigma), repeat(plot)))
+    pool.close()
+    pool.join()
     print('Analysis complete.')
     return pd.DataFrame(
         res, columns=['a', 'sig_a', 'b', 'sig_b',

--- a/chamber/analysis/experiments.py
+++ b/chamber/analysis/experiments.py
@@ -530,11 +530,13 @@ def _add_rh(
 
 
 def _multi_rh(dataframe, param_list):
+    """Apply `_get_coolprop_rh` to the argument dataframe."""
     df = dataframe.loc[:, param_list].apply(_get_coolprop_rh, axis=1)
     return df
 
 
 def _multi_rh_err(dataframe, param_list):
+    """Apply `_get_coolprop_rh_err` to the argument dataframe."""
     df = dataframe.loc[:, param_list].apply(_get_coolprop_rh_err, axis=1)
     return df
 

--- a/chamber/analysis/experiments.py
+++ b/chamber/analysis/experiments.py
@@ -44,57 +44,6 @@ CPU_COUNT = cpu_count()
 # --------------------------------------------------------------------------- #
 # Public Functions
 # --------------------------------------------------------------------------- #
-def results_from_csv(
-        filepath,
-        purge=False,
-        param_list=['PressureSmooth', 'TeSmooth', 'DewPointSmooth'],
-        sigma=4e-8,
-        steps=100,
-        ):
-    """
-    Get results from csv.
-
-    This function opens a csv file, preprocesses the data, performs the
-    chi-square regression, and returns the data and results in separate
-    `DataFrames`.
-
-    Parameters
-    ----------
-    filepath : str, pathlib.Path, py._path.local.LocalPath or any \
-        object with a read() method
-        The filepath to a csv file.
-    purge : bool
-        If `True` the original (raw) data is removed from the
-        preprocessed `DataFrame`. If `False` the raw data remains in
-        the resulting 'DataFrame'. Defaults to `False`.
-    param_list : list(str)
-        List of parameters to use to calculate the relative humidity using the
-        CoolProp API, see `_get_coolprop_rh` docstring for more detail.
-        Defaults to: `['PressureSmooth', 'TeSmooth', 'DewPointSmooth']`.
-    sigma : float
-        Standard deviation of mass measurement. Defaults to 4e-8 accoriding to
-        the spec sheet.
-    steps : int
-        Steps to increase the `half_length`.
-
-    Returns
-    -------
-    (DataFrame, DataFrame)
-        A tuple of a `DataFrame` containing the preprocessed experimental data
-        and a second `DataFrame` containing the chi-square analysis results.
-
-    Examples
-    --------
-    .. todo:: Examples.
-
-    """
-    dataframe = pd.read_csv(filepath)
-    dataframe = preprocess(dataframe, param_list=param_list, purge=purge)
-    results = mass_transfer(dataframe, sigma=sigma, steps=steps)
-
-    return (dataframe, results)
-
-
 def preprocess(
         dataframe,
         param_list=['PressureSmooth', 'TeSmooth', 'DewPointSmooth'],

--- a/chamber/analysis/experiments.py
+++ b/chamber/analysis/experiments.py
@@ -19,7 +19,7 @@ Functions
 """
 from itertools import repeat
 import math
-from multiprocessing import cpu_count, Pool
+import multiprocessing as multi
 
 from CoolProp.HumidAirProp import HAPropsSI
 import pandas as pd
@@ -38,7 +38,7 @@ RH_STEP_PCT = 5
 R_TUBE = 1.5e-2
 A_TUBE = math.pi * pow(R_TUBE, 2)
 
-CPU_COUNT = cpu_count()
+CPU_COUNT = multi.cpu_count()
 
 
 # --------------------------------------------------------------------------- #
@@ -150,7 +150,7 @@ def mass_transfer(dataframe, sigma=4e-8, steps=100, plot=False):
     print('Starting analysis...')
     rh_targets = _get_valid_rh_targets(dataframe)
     res = []
-    pool = Pool(CPU_COUNT)
+    pool = multi.Pool(CPU_COUNT)
     for rh in tqdm(rh_targets):
         idx = _get_target_idx(dataframe, rh)
         res += pool.starmap(_multi_mass, zip(repeat(dataframe), repeat(rh),
@@ -256,7 +256,7 @@ def _add_avg_te(dataframe, purge=False):
         If `purge == True` then TC4-TC13 will have been dropped.
 
     """
-    pool = Pool(CPU_COUNT)
+    pool = multi.Pool(CPU_COUNT)
     df_stack = np.array_split(dataframe, CPU_COUNT)
     dataframe['Te'] = pd.concat(pool.map(_multi_te, df_stack))
     pool.close()
@@ -474,7 +474,7 @@ def _add_rh(
         was dropped.
 
     """
-    pool = Pool(CPU_COUNT)
+    pool = multi.Pool(CPU_COUNT)
     df_stack = np.array_split(dataframe, CPU_COUNT)
     dataframe['RH'] = pd.concat(
         pool.starmap(_multi_rh, zip(df_stack, repeat(param_list)))

--- a/chamber/data/dml.py
+++ b/chamber/data/dml.py
@@ -165,10 +165,13 @@ get_info_df = ("SELECT Temperature, Pressure, Duty, IsMass, Reservoir, "
                "Setting.SettingId=Test.SettingId WHERE TestId={};")
 
 add_best_fit = ("UPDATE RHTargets INNER JOIN (SELECT * FROM Results WHERE "
-                "TestId={0} AND (RH, SigB) IN (SELECT RH, MIN(SigB) FROM "
-                "Results WHERE TestId={0} AND ABS(Q-0.5) < {1} GROUP BY RH)) "
-                "AS BestFit SET RHTargets.Nu=BestFit.Nu WHERE "
-                "RHTargets.RH=BestFit.RH AND "
+                "TestId={0} AND REPLACE(REPLACE(CONCAT(RH, SigB+0), '.', ''), "
+                "'0', '')+0 IN (SELECT REPLACE(REPLACE(CONCAT(RH, Min(SigB)), "
+                "'.', ''), '0', '')+0 FROM Results WHERE TestId={0} AND "
+                "CONCAT(RH, ABS(Q-0.5)) IN (SELECT CONCAT(RH, "
+                "Min(ABS(Q-0.5))) FROM Results WHERE TestId={0} AND Nu>{1} "
+                "GROUP BY RH) GROUP BY RH)) AS BestFit SET "
+                "RHTargets.Nu=BestFit.Nu WHERE RHTargets.RH=BestFit.RH AND "
                 "RHTargets.TestId=BestFit.TestId")
 
 settings_df = ('SELECT Pressure, Temperature, Reservoir, TestId FROM Setting '

--- a/chamber/data/sqldb.py
+++ b/chamber/data/sqldb.py
@@ -1163,25 +1163,20 @@ def add_analysis(cnx, test_id, steps=1, nu_min=100):
 
         # --------------------------------------------------------------------
         # RHTargets: call add_rh_targets
-        _add_rh_targets(cur, analyzed_df, test_id)
+        assert _add_rh_targets(cur, analyzed_df, test_id)
         assert cnx.in_transaction
-        cnx.commit()
-        assert not cnx.in_transaction
 
         # --------------------------------------------------------------------
         # Results: call add_results
-        _add_results(cur, analyzed_df, test_id)
+        assert _add_results(cur, analyzed_df, test_id)
+        assert cnx.in_transaction
+
+        assert _add_best_fit(cur, test_id, nu_min=nu_min)
+
         assert cnx.in_transaction
         cnx.commit()
         assert not cnx.in_transaction
-
-        _add_best_fit(cur, test_id, nu_min=nu_min)
-        assert cnx.in_transaction
-        cnx.commit()
-        assert not cnx.in_transaction
-
         assert cur.close()
-
         return True
     except mysql.connector.Error as err:
         # --------------------------------------------------------------------

--- a/chamber/data/sqldb.py
+++ b/chamber/data/sqldb.py
@@ -737,13 +737,9 @@ def _get_temp_info(tdms_obj, tdms_idx, couple_idx):
 
     """
     # ------------------------------------------------------------------------
-    # Compile a regular expression to use when obtaining TC obervations
-    regex = re.compile(r'^(\d){3}.(\d){2}$')
     # Get and format the temperature observation
     temp_info = '{:.2f}'.format(
         tdms_obj.object("Data", "TC{}".format(couple_idx)).data[tdms_idx])
-    if not regex.search(temp_info):
-        return
     return temp_info
 
 

--- a/chamber/data/sqldb.py
+++ b/chamber/data/sqldb.py
@@ -1078,7 +1078,7 @@ def _add_results(cur, analyzed_df, test_id):
     return True
 
 
-def _add_best_fit(cur, test_id, q_max=0.05):
+def _add_best_fit(cur, test_id, nu_min=100):
     """
     Add the best Chi2 fit to the 'RHTargets' Table.
 
@@ -1092,9 +1092,8 @@ def _add_best_fit(cur, test_id, q_max=0.05):
     test_id : int
         TestID for the MySQL database, which is the primary key for the Test
         table.
-    q_max : float
-        The cutoff value for ABS(Q-0.5) for determining best fit.
-        Defaults to 0.05.
+    nu_min : int
+        The minimum degrees of freedom for an accepted Chi2 fit.
 
     Returns
     -------
@@ -1108,15 +1107,15 @@ def _add_best_fit(cur, test_id, q_max=0.05):
     >>> cnx = connect('my-schema')
     >>> cur = cnx.cursor()
     >>> test_id = 1
-    >>> _add_best_fit(cnx, test_id, q_max=0.1)
+    >>> _add_best_fit(cnx, test_id, nu_min=150)
     True
 
     """
-    cur.execute(dml.add_best_fit.format(test_id, q_max))
+    cur.execute(dml.add_best_fit.format(test_id, nu_min))
     return True
 
 
-def add_analysis(cnx, test_id, steps=1, q_max=0.05):
+def add_analysis(cnx, test_id, steps=1, nu_min=100):
     """
     Pull, analyze, and insert analysis results into MySQL database.
 
@@ -1133,9 +1132,8 @@ def add_analysis(cnx, test_id, steps=1, q_max=0.05):
         table.
     steps : int
         The step size for Chi2 analysis. Defaults to 1.
-    q_max : float
-        The cutoff value for ABS(Q-0.5) for determining best fit.
-        Defaults to 0.05.
+    nu_min : float
+        The minimum degrees of freedom for an accepted Chi2 fit.
 
     Returns
     -------
@@ -1148,7 +1146,7 @@ def add_analysis(cnx, test_id, steps=1, q_max=0.05):
 
     >>> cnx = connect('my-schema')
     >>> test_id = 1
-    >>> add_analysis(cnx, test_id)
+    >>> add_analysis(cnx, test_id, steps=2, nu_min=150)
     True
 
     """
@@ -1177,7 +1175,7 @@ def add_analysis(cnx, test_id, steps=1, q_max=0.05):
         cnx.commit()
         assert not cnx.in_transaction
 
-        _add_best_fit(cur, test_id, q_max=q_max)
+        _add_best_fit(cur, test_id, nu_min=nu_min)
         assert cnx.in_transaction
         cnx.commit()
         assert not cnx.in_transaction

--- a/chamber/scripts/db_check.py
+++ b/chamber/scripts/db_check.py
@@ -139,7 +139,6 @@ def exp_plot(cnx):
                 label='LowRH A' if 'LowRH A' not in label_list else '')
             if 'HighRH A' not in label_list:
                 label_list = label_list + ['HighRH A', 'LowRH A']
-            print(label_list)
         else:
             plt.scatter(
                 sdf.loc[(sdf['TestId'] == tid) & (sdf['Reservoir'] == 1),

--- a/chamber/scripts/db_check.py
+++ b/chamber/scripts/db_check.py
@@ -171,7 +171,28 @@ def exp_plot(cnx):
     return True
 
 
+def add_analysis(cnx):
+    """docstring."""
+    add_analysis = input('Add analysis to database? [y/n]')
+    if add_analysis == 'y':
+        test_id = input('Which TestId would you like to analyze [ex. "3"]')
+        print('Adding TestId ', test_id, '...')
+        sqldb.add_analysis(cnx, test_id)
+        print('Done.')
+        return True
+    elif add_analysis == 'n':
+        print('No analysis added.')
+        return False
+    else:
+        print('Incorrect input, analysis aborted.')
+        return False
+
+
 if __name__ == '__main__':
     schema = sys.argv[1]
     cnx = sqldb.connect(schema)
     exp_plot(cnx)
+    add = True
+    while add is True:
+        add = add_analysis(cnx)
+        exp_plot(cnx)

--- a/chamber/scripts/db_check.py
+++ b/chamber/scripts/db_check.py
@@ -171,7 +171,7 @@ def exp_plot(cnx):
 
 
 def add_analysis(cnx):
-    """docstring."""
+    """Propmt user for a TestId to apply and insert analysis into database."""
     add_analysis = input('Add analysis to database? [y/n]')
     if add_analysis == 'y':
         test_id = input('Which TestId would you like to analyze [ex. "3"]')

--- a/chamber/scripts/db_check.py
+++ b/chamber/scripts/db_check.py
@@ -122,7 +122,7 @@ def exp_plot(cnx):
     tid_df = _get_analysis_tid_df(cnx)
     label_list = []
     for tid in sdf.TestId:
-        if tid in sdf[sdf.TestId.isin(tid_df.TestId)].TestId:
+        if tid in sdf[sdf.TestId.isin(tid_df.TestId)].TestId.data:
             plt.scatter(
                 sdf.loc[(sdf['TestId'] == tid) & (sdf['Reservoir'] == 1),
                         'Temperature'],

--- a/chamber/scripts/db_check.py
+++ b/chamber/scripts/db_check.py
@@ -171,7 +171,7 @@ def exp_plot(cnx):
 
 
 def add_analysis(cnx):
-    """docstring."""
+    """Propmt user for a Testid to apply and insert analysis into database."""
     add_analysis = input('Add analysis to database? [y/n]')
     if add_analysis == 'y':
         test_id = input('Which TestId would you like to analyze [ex. "3"]')

--- a/chamber/scripts/db_check.py
+++ b/chamber/scripts/db_check.py
@@ -171,7 +171,7 @@ def exp_plot(cnx):
 
 
 def add_analysis(cnx):
-    """Propmt user for a Testid to apply and insert analysis into database."""
+    """docstring."""
     add_analysis = input('Add analysis to database? [y/n]')
     if add_analysis == 'y':
         test_id = input('Which TestId would you like to analyze [ex. "3"]')

--- a/tests/analysis/test_experiments.py
+++ b/tests/analysis/test_experiments.py
@@ -15,6 +15,7 @@ TARGET_RH = 0.15
 TARGET_IDX = 12770
 HALF_LEN = 7000
 SIGMA = 4e-8
+PARAM_LIST = ['PressureSmooth', 'TeSmooth', 'DewPointSmooth']
 
 
 @pytest.fixture(scope='module')
@@ -195,11 +196,6 @@ def test__add_smooth_pressure(df_01, df_bad):
     plt.show()
 
 
-def test__add_all_smooth(df_01):
-    # df_01.drop()
-    pass
-
-
 def test__get_rh():
     rh = expr._get_coolprop_rh([101325, 290, 275])
     assert math.isclose(rh, 0.36377641815012024)
@@ -212,13 +208,35 @@ def test__get_coolprop_rh_err():
     assert math.isclose(rh, 0.005145568640554932)
 
 
+def test__multi_rh(df_01):
+    rh = expr._multi_rh(df_01, param_list=PARAM_LIST)
+    plt.plot(rh, label='RH')
+
+    plt.legend()
+    plt.xlabel('time/s')
+    plt.ylabel('RH')
+    plt.title('Relative Humidity')
+    plt.show()
+
+
+def test__multi_rh_err(df_01):
+    rh_err = expr._multi_rh_err(df_01, param_list=PARAM_LIST)
+    plt.plot(rh_err, label='SigRH Function')
+
+    plt.legend()
+    plt.xlabel('time/s')
+    plt.ylabel('SigRH')
+    plt.title('Relative Humidity Error')
+    plt.show()
+
+
 def test__add_rh(df_01):
     assert 'RH' not in set(df_01)
 
     df_01 = expr._add_rh(df_01)
     assert 'RH' in set(df_01)
 
-    plt.plot(df_01.RH, label='RH')
+    plt.errorbar(df_01.Idx, df_01.RH, yerr=df_01.SigRH, label='RH')
 
     plt.legend()
     plt.xlabel('time/s')

--- a/tests/analysis/test_experiments.py
+++ b/tests/analysis/test_experiments.py
@@ -16,10 +16,106 @@ TARGET_IDX = 12770
 HALF_LEN = 7000
 SIGMA = 4e-8
 PARAM_LIST = ['PressureSmooth', 'TeSmooth', 'DewPointSmooth']
+TC_LIST = ['TC{0}'.format(i) for i in range(4, 14)]
+
+# ----------------------------------------------------------------------------
+# Test _zero_time global variables
+ZERO_TIME_STATS = pd.DataFrame(dict(
+    idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
+    Idx=[20001, 20001e4, 33338333.5, 1e4, 0, 2e4]
+    )
+).set_index('idx')
+
+# ----------------------------------------------------------------------------
+# Test _format_temp global variables
+FORMAT_TEMP_STATS = pd.DataFrame(dict(
+    idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
+    TC4=[20001, 5811389.8000000007, 0.011664499825010125, 290.55496225188745,
+         290.30000000000001, 291.0],
+    TC5=[20001, 5802036.4999999991, 0.0011072256387185673, 290.08732063396826,
+         290.0, 290.10000000000002],
+    TC6=[20001, 5802257.0999999996, 0.00016227763611826785, 290.09835008249587,
+         290.0, 290.10000000000002],
+    TC7=[20001, 5805846.3000000007, 0.0020231846407686763, 290.27780110994456,
+         290.19999999999999, 290.39999999999998],
+    TC8=[20001, 5806176.5, 0.001810625518724122, 290.29431028448579,
+         290.19999999999999, 290.39999999999998],
+    TC9=[20001, 5800010.8000000007, 0.0012011281435933669, 289.98604069796517,
+         289.89999999999998, 290.0],
+    TC10=[20001, 5797574.1000000015, 0.0022981399430012824, 289.8642117894106,
+          289.80000000000001, 289.89999999999998],
+    TC11=[20001, 5799775.1000000006, 0.0019117281135951898, 289.97425628718565,
+          289.89999999999998, 290.0],
+    TC12=[20001, 5796716.9000000013, 0.0016794867756600713, 289.82135393230345,
+          289.80000000000001, 289.89999999999998],
+    TC13=[20001, 5797926.2000000011, 0.0014878223088835407, 289.88181590920459,
+          289.80000000000001, 289.89999999999998]
+    )
+).set_index('idx')
+
+
+# ----------------------------------------------------------------------------
+# Test _format_dew_point global variables
+FORMAT_DP_STATS = pd.DataFrame(dict(
+    idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
+    DewPoint=[20001, 5269690.5000000009, 3.5677552185390735,
+              263.47135143242843, 259.0, 266.39999999999998]
+    )
+).set_index('idx')
+
+# ----------------------------------------------------------------------------
+# Test _format_presssure global variables
+FORMAT_P_STATS = pd.DataFrame(dict(
+    idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
+    Pressure=[20001, 2005196296.0, 1723.9397677566121, 100254.802059897,
+              100078.0, 100358.0]
+    )
+).set_index('idx')
+
+# ----------------------------------------------------------------------------
+# Test _add_avg_te global variables
+AVG_T_STATS = pd.DataFrame(dict(
+    idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
+    Te=[20001, 5801992.4000000004, 0.0014759478526079042, 290.08511574421283,
+        290.0, 290.19999999999999]
+    )
+).set_index('idx')
+
+# ----------------------------------------------------------------------------
+# Test _multi_rh global variables
+RH_STATS = pd.DataFrame(dict(
+    idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
+    RH=[20001, 2803.8464972706283, 0.00051402847579061852, 0.14018531559775152,
+        0.093374396753349437, 0.1784676778434911]
+    )
+).set_index('idx')
+
+# ----------------------------------------------------------------------------
+# Test _multi_rh_err global variables
+SIGRH_STATS = pd.DataFrame(dict(
+    idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
+    SigRH=[20001, 49.954031383018787, 1.3734073708436497e-07,
+           0.0024975766903164234, 0.0017245551439777212, 0.0031181436063756618]
+    )
+).set_index('idx')
+
+# ----------------------------------------------------------------------------
+# Test _add_rh global variables
+RH_STATS_JOIN = RH_STATS.join(SIGRH_STATS)
 
 
 @pytest.fixture(scope='module')
 def df_01():
+    """Fixture to instantiate only one pd.DataFrame object for testing."""
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    filename = '1atm_290K_0duty_44mm_Mass_FanOff_LowRH_Sample.csv'
+    filepath = os.path.join(dir_path, 'csv_test_files', filename)
+    dataframe = pd.read_csv(filepath)
+    return dataframe
+
+
+@pytest.fixture(scope='module')
+def df_01_original():
     """Fixture to instantiate only one pd.DataFrame object for testing."""
     dir_path = os.path.dirname(os.path.realpath(__file__))
     filename = '1atm_290K_0duty_44mm_Mass_FanOff_LowRH_Sample.csv'
@@ -39,10 +135,20 @@ def df_bad():
 
 def test__zero_time(df_01, df_bad):
     """Test _zero_time."""
-    assert df_01.Idx[0] == 8000
+    assert df_01.Idx.data[0] == 8000
+    assert df_01.Idx.data[-1] == 28000
 
     df_01 = expr._zero_time(df_01)
-    assert df_01.Idx[0] == 0
+    for col in ZERO_TIME_STATS:
+        assert df_01[col].count() == ZERO_TIME_STATS.loc['cnt', col]
+        assert df_01[col].sum() == ZERO_TIME_STATS.loc['sum', col]
+        assert df_01[col].var() == ZERO_TIME_STATS.loc['var', col]
+        assert df_01[col].mean() == ZERO_TIME_STATS.loc['avg', col]
+        assert df_01[col].min() == ZERO_TIME_STATS.loc['min', col]
+        assert df_01[col].max() == ZERO_TIME_STATS.loc['max', col]
+
+    assert df_01.Idx.data[0] == 0
+    assert df_01.Idx.data[-1] == 20000
 
     with pytest.raises(AttributeError) as err:
         expr._zero_time(df_bad)
@@ -50,11 +156,19 @@ def test__zero_time(df_01, df_bad):
 
 
 def test__format_temp(df_01, df_bad):
+    """Test _format_temp."""
     assert math.isclose(df_01.TC4[0], 290.799)
     assert math.isclose(df_01.TC7[100], 290.358)
     assert math.isclose(df_01.TC11[8000], 289.975)
 
     df_01 = expr._format_temp(df_01)
+    for col in FORMAT_TEMP_STATS:
+        assert df_01[col].count() == FORMAT_TEMP_STATS.loc['cnt', col]
+        assert df_01[col].sum() == FORMAT_TEMP_STATS.loc['sum', col]
+        assert df_01[col].var() == FORMAT_TEMP_STATS.loc['var', col]
+        assert df_01[col].mean() == FORMAT_TEMP_STATS.loc['avg', col]
+        assert df_01[col].min() == FORMAT_TEMP_STATS.loc['min', col]
+        assert df_01[col].max() == FORMAT_TEMP_STATS.loc['max', col]
 
     assert math.isclose(df_01.TC4[0], round(290.799, 1))
     assert math.isclose(df_01.TC7[100], round(290.358, 1))
@@ -70,11 +184,19 @@ def test__format_temp(df_01, df_bad):
 
 
 def test__format_dew_point(df_01, df_bad):
+    """Test _format_dew_point."""
     assert math.isclose(df_01.DewPoint[0], 259.04)
     assert math.isclose(df_01.DewPoint[100], 259.145)
     assert math.isclose(df_01.DewPoint[8000], 263.562)
 
     df_01 = expr._format_dew_point(df_01)
+    for col in FORMAT_DP_STATS:
+        assert df_01[col].count() == FORMAT_DP_STATS.loc['cnt', col]
+        assert df_01[col].sum() == FORMAT_DP_STATS.loc['sum', col]
+        assert df_01[col].var() == FORMAT_DP_STATS.loc['var', col]
+        assert df_01[col].mean() == FORMAT_DP_STATS.loc['avg', col]
+        assert df_01[col].min() == FORMAT_DP_STATS.loc['min', col]
+        assert df_01[col].max() == FORMAT_DP_STATS.loc['max', col]
 
     assert math.isclose(df_01.DewPoint[0], round(259.04, 1))
     assert math.isclose(df_01.DewPoint[100], round(259.145, 1))
@@ -88,11 +210,19 @@ def test__format_dew_point(df_01, df_bad):
 
 
 def test__format_pressure(df_01, df_bad):
+    """Test _format_pressure."""
     assert math.isclose(df_01.Pressure[0], 100156.841)
     assert math.isclose(df_01.Pressure[100], 100161.21800000001)
     assert math.isclose(df_01.Pressure[8000], 100266.27900000001)
 
     df_01 = expr._format_pressure(df_01)
+    for col in FORMAT_P_STATS:
+        assert df_01[col].count() == FORMAT_P_STATS.loc['cnt', col]
+        assert df_01[col].sum() == FORMAT_P_STATS.loc['sum', col]
+        assert df_01[col].var() == FORMAT_P_STATS.loc['var', col]
+        assert df_01[col].mean() == FORMAT_P_STATS.loc['avg', col]
+        assert df_01[col].min() == FORMAT_P_STATS.loc['min', col]
+        assert df_01[col].max() == FORMAT_P_STATS.loc['max', col]
 
     assert math.isclose(df_01.Pressure[0], round(100156.841, 0))
     assert math.isclose(df_01.Pressure[100], round(100161.21800000001, 0))
@@ -106,10 +236,22 @@ def test__format_pressure(df_01, df_bad):
 
 
 def test__add_avg_te(df_01, df_bad):
+    """Test add_avg_te."""
     assert 'Te' not in set(df_01)
-
+    purged = expr._add_avg_te(df_01.copy(), purge=True)
+    for tc in TC_LIST:
+        assert tc not in set(purged)
+    assert 'Te' in set(purged)
     df_01 = expr._add_avg_te(df_01)
     assert 'Te' in set(df_01)
+
+    for col in AVG_T_STATS:
+        assert df_01[col].count() == AVG_T_STATS.loc['cnt', col]
+        assert df_01[col].sum() == AVG_T_STATS.loc['sum', col]
+        assert df_01[col].var() == AVG_T_STATS.loc['var', col]
+        assert df_01[col].mean() == AVG_T_STATS.loc['avg', col]
+        assert df_01[col].min() == AVG_T_STATS.loc['min', col]
+        assert df_01[col].max() == AVG_T_STATS.loc['max', col]
 
     tc_keys = ['TC{}'.format(i) for i in range(4, 14)]
     mean = np.mean(df_01.loc[0, tc_keys])
@@ -134,8 +276,11 @@ def test__add_avg_te(df_01, df_bad):
 
 
 def test__add_smooth_avg_te(df_01, df_bad):
+    """Test _add_smooth_avg_te."""
     assert 'TeSmooth' not in set(df_01)
-
+    purged = expr._add_smooth_avg_te(df_01.copy(), purge=True)
+    assert 'Te' not in set(purged)
+    assert 'TeSmooth' in set(purged)
     df_01 = expr._add_smooth_avg_te(df_01)
     assert 'TeSmooth' in set(df_01)
 
@@ -154,8 +299,11 @@ def test__add_smooth_avg_te(df_01, df_bad):
 
 
 def test__add_smooth_dew_point(df_01, df_bad):
+    """Test _add_smooth_dew_point."""
     assert 'DewPointSmooth' not in set(df_01)
-
+    purged = expr._add_smooth_dew_point(df_01.copy(), purge=True)
+    assert 'DewPoint' not in set(purged)
+    assert 'DewPointSmooth' in set(purged)
     df_01 = expr._add_smooth_dew_point(df_01)
     assert 'DewPointSmooth' in set(df_01)
 
@@ -175,8 +323,11 @@ def test__add_smooth_dew_point(df_01, df_bad):
 
 
 def test__add_smooth_pressure(df_01, df_bad):
+    """Test _add_smooth_pressure."""
     assert 'PressureSmooth' not in set(df_01)
-
+    purged = expr._add_smooth_pressure(df_01.copy(), purge=True)
+    assert 'Pressure' not in set(purged)
+    assert 'PressureSmooth' in set(purged)
     df_01 = expr._add_smooth_pressure(df_01)
     assert 'PressureSmooth' in set(df_01)
 
@@ -196,12 +347,14 @@ def test__add_smooth_pressure(df_01, df_bad):
     plt.show()
 
 
-def test__get_rh():
+def test__get_coolprop_rh():
+    """Test _get_rh."""
     rh = expr._get_coolprop_rh([101325, 290, 275])
     assert math.isclose(rh, 0.36377641815012024)
 
 
 def test__get_coolprop_rh_err():
+    """Test _get_coolprop_rh_err."""
     rh = expr._get_coolprop_rh_err([101325, 290, 275])
     assert math.isclose(rh, 0.005239925265924594)
     rh = expr._get_coolprop_rh_err([70000, 290, 273])
@@ -209,7 +362,16 @@ def test__get_coolprop_rh_err():
 
 
 def test__multi_rh(df_01):
+    """Test _multi_rh."""
     rh = expr._multi_rh(df_01, param_list=PARAM_LIST)
+    for col in RH_STATS:
+        assert rh.count() == RH_STATS.loc['cnt', col]
+        assert rh.sum() == RH_STATS.loc['sum', col]
+        assert rh.var() == RH_STATS.loc['var', col]
+        assert rh.mean() == RH_STATS.loc['avg', col]
+        assert rh.min() == RH_STATS.loc['min', col]
+        assert rh.max() == RH_STATS.loc['max', col]
+
     plt.plot(rh, label='RH')
 
     plt.legend()
@@ -220,7 +382,16 @@ def test__multi_rh(df_01):
 
 
 def test__multi_rh_err(df_01):
+    """Test _multi_rh_err."""
     rh_err = expr._multi_rh_err(df_01, param_list=PARAM_LIST)
+    for col in SIGRH_STATS:
+        assert rh_err.count() == SIGRH_STATS.loc['cnt', col]
+        assert rh_err.sum() == SIGRH_STATS.loc['sum', col]
+        assert rh_err.var() == SIGRH_STATS.loc['var', col]
+        assert rh_err.mean() == SIGRH_STATS.loc['avg', col]
+        assert rh_err.min() == SIGRH_STATS.loc['min', col]
+        assert rh_err.max() == SIGRH_STATS.loc['max', col]
+
     plt.plot(rh_err, label='SigRH Function')
 
     plt.legend()
@@ -231,10 +402,21 @@ def test__multi_rh_err(df_01):
 
 
 def test__add_rh(df_01):
+    """Test _add_rh."""
     assert 'RH' not in set(df_01)
-
+    purged = expr._add_rh(df_01.copy(), purge=True)
+    assert 'DewPointSmooth' not in set(purged)
+    assert 'RH' in set(purged)
     df_01 = expr._add_rh(df_01)
     assert 'RH' in set(df_01)
+
+    for col in RH_STATS_JOIN:
+        assert df_01[col].count() == RH_STATS_JOIN.loc['cnt', col]
+        assert df_01[col].sum() == RH_STATS_JOIN.loc['sum', col]
+        assert df_01[col].var() == RH_STATS_JOIN.loc['var', col]
+        assert df_01[col].mean() == RH_STATS_JOIN.loc['avg', col]
+        assert df_01[col].min() == RH_STATS_JOIN.loc['min', col]
+        assert df_01[col].max() == RH_STATS_JOIN.loc['max', col]
 
     plt.errorbar(df_01.Idx, df_01.RH, yerr=df_01.SigRH, label='RH')
 
@@ -246,8 +428,11 @@ def test__add_rh(df_01):
 
 
 def test__get_max_half_len(df_01):
+    """Test _get_max_half_length."""
     max_window = expr._get_max_half_len(df_01, TARGET_IDX)
     assert max_window == (len(df_01)-1) - TARGET_IDX
+    max_limit = expr._get_max_half_len(df_01, TARGET_IDX, max_=10)
+    assert max_limit == 10
 
     fail_list = [0, -1, -2, len(df_01)-1, len(df_01), len(df_01)+1]
 
@@ -262,6 +447,7 @@ def test__get_max_half_len(df_01):
 
 
 def test__get_rh_idx(df_01):
+    """Test _get_rh_idx."""
     idx = expr._get_target_idx(df_01, TARGET_RH)
     assert idx == TARGET_IDX
     rh = df_01.RH[idx]
@@ -279,6 +465,7 @@ def test__get_rh_idx(df_01):
 
 
 def test__get_stat_group(df_01):
+    """Test _get_stat_group."""
     time, mass = expr._get_stat_group(df_01, TARGET_IDX, HALF_LEN)
 
     assert len(time) == 2*HALF_LEN + 1
@@ -299,11 +486,13 @@ def test__get_stat_group(df_01):
 
 
 def test__get_valid_rh_targets(df_01):
+    """Test _get_valid_rh_targets."""
     rh_list = expr._get_valid_rh_targets(df_01)
     assert rh_list == [0.1, 0.15]
 
 
 def test__half_len_gen(df_01):
+    """Test _half_len_gen."""
     half_len_list = list(
         expr._half_len_gen(df_01, TARGET_IDX, steps=1000)
     )
@@ -322,7 +511,13 @@ def test__half_len_gen(df_01):
         )
 
 
-def test__analysis(df_01):
+def test_preprocess(df_01, df_01_original):
+    """Test preprocess."""
+    pd.testing.assert_frame_equal(expr.preprocess(df_01_original), df_01)
+
+
+def test_mass_transfer(df_01):
+    """Test _analysis."""
     df_res = expr.mass_transfer(df_01, sigma=SIGMA, steps=1000, plot=True)
     assert math.isclose(df_res.a[0], 0.09929181759175223)
     assert math.isclose(df_res.sig_a[0], 1.882350488972039e-09)

--- a/tests/data/test_sqldb.py
+++ b/tests/data/test_sqldb.py
@@ -311,7 +311,7 @@ BEST_FIT_STATS_DF = pd.DataFrame(dict(
     idx=['cnt', 'sum', 'var', 'avg', 'min', 'max'],
     RH=[15, 6.75, 0.04666666666666666, 0.450000, 0.10, 0.80],
     TestId=[15, 15, 0, 1, 1, 1],
-    Nu=[15, 37785, 1998933.3333333333, 2519.0000, 399, 5399],
+    Nu=[15, 36585, 2049066.666666667, 2439.0000, 199, 5199],
     )
 ).set_index('idx')
 
@@ -1067,7 +1067,7 @@ def test__add_best_fit(results_cnx):
     """Test _add_best_fit."""
     results_cur = results_cnx.cursor()
     # Add best Chi2 results to RHTargets
-    assert sqldb._add_best_fit(results_cur, ANALYSIS_TEST_ID, q_max=0.5)
+    assert sqldb._add_best_fit(results_cur, ANALYSIS_TEST_ID)
 
     # Check accuracy of added data
     for col in BEST_FIT_STATS_DF.columns.values:
@@ -1093,7 +1093,7 @@ def test_add_analysis(results_cnx):
     assert not results_cnx.in_transaction
 
     assert sqldb.add_analysis(
-        results_cnx, ANALYSIS_TEST_ID, steps=100, q_max=0.5)
+        results_cnx, ANALYSIS_TEST_ID, steps=100)
 
     # ------------------------------------------------------------------------
     # Test correct RHTargets input
@@ -1125,7 +1125,7 @@ def test_add_analysis(results_cnx):
     # ------------------------------------------------------------------------
     # Test adding the same analysis again
     assert sqldb.add_analysis(
-        results_cnx, ANALYSIS_TEST_ID, steps=100, q_max=0.5) is None
+        results_cnx, ANALYSIS_TEST_ID, steps=100) is None
 
     # ------------------------------------------------------------------------
     # Check that the database is uneffected


### PR DESCRIPTION
Adds an analysis option to run analysis after the plot detailing what is in the database is produced. Also uses multiprocessing to run analysis at different Nu's in paralell, dropping the analysis time for a larger test from 80-90 minutes to 10-15 minutes (this will vary by the amount of available cores of course).